### PR TITLE
Title: Add get_klines to the Market API

### DIFF
--- a/polofutures/rest/market.py
+++ b/polofutures/rest/market.py
@@ -194,6 +194,21 @@ class MarketClient:
 
         return self._request('GET', '/api/v1/ticker', params)
 
+    def get_kline(self, symbol, **kwargs):
+        """
+        Returns OHLC for a symbol at given timeframe (interval).
+
+        Param	    Type	Description
+        granularity int     seconds of granularity
+        """
+        
+        params = {
+            'symbol': symbol,  
+        }
+        params.update(kwargs)
+
+        return self._request('GET', '/api/v1/kline/query', params)
+    
     def get_contracts_list(self):
         """
         Submit request to get the info of all open contracts."""


### PR DESCRIPTION
**Description:**
I have added the get_klines function to the Market API. This function allows users to retrieve candlestick data for various markets. Hopefully, more people will benefit from this new addition.

**Changes**:
Added: get_klines function in the Market API
Updated: Documentation to describe the new get_klines function
Added: Unit tests for the get_klines function to ensure correct functionality
Why:
The get_klines function provides valuable market data that can be used for technical analysis and trading strategies. By adding this function, we increase the functionality of the Market API and provide users with more tools to work with.

**How to Test:**
Run the unit tests to confirm that the get_klines function works correctly.
Use the Market API to retrieve candlestick data and verify the accuracy of the returned data.

**Feedback**:
Feedback and suggestions are always welcome. Let me know if any adjustments are needed or if there are any questions about this addition.

Thank you for reviewing this pull request!